### PR TITLE
Point repo and docs site URLs at the current org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,4 +762,4 @@ Rules that hold regardless of task:
   `add_method_by_category/`) and evaluating steering pipelines.
 - `examples/notebooks/`: runnable references for every method, the generic controls, and use-case studies.
 - `tests/index.md`: test-suite layout and the pattern for adding control tests.
-- Hosted documentation: <https://ibm.github.io/steerability/>.
+- Hosted documentation: <https://generative-computing.github.io/steerability/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-[fork]: https://github.com/IBM/steerability/fork
-[pr]: https://github.com/IBM/steerability/compare
+[fork]: https://github.com/generative-computing/steerability/fork
+[pr]: https://github.com/generative-computing/steerability/compare
 [released]: https://help.github.com/articles/github-terms-of-service/
 
 We are pleased that you would like to contribute to Steerability. We welcome both reporting issues and submitting pull requests.
@@ -13,7 +13,7 @@ Please make sure to include any potentially useful information in the issue, so 
 - Python versions
 
 ## Contributing a change
-Contributions to this project are [released][released] to the public under the project's [opensource license](https://github.com/IBM/steerability/blob/main/LICENSE).
+Contributions to this project are [released][released] to the public under the project's [opensource license](https://github.com/generative-computing/steerability/blob/main/LICENSE).
 
 Contributors must _sign off_ that they adhere to these requirements by adding a `Signed-off-by` line to all commit messages with an email address that matches the commit author:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-![Steerability](https://github.com/IBM/steerability/raw/main/docs/assets/logo_slim_darkmode.png#gh-dark-mode-only)
-![Steerability](https://github.com/IBM/steerability/raw/main/docs/assets/logo_slim_lightmode.png#gh-light-mode-only)
+![Steerability](https://github.com/generative-computing/steerability/raw/main/docs/assets/logo_slim_darkmode.png#gh-dark-mode-only)
+![Steerability](https://github.com/generative-computing/steerability/raw/main/docs/assets/logo_slim_lightmode.png#gh-light-mode-only)
 
 [//]: # (to add: arxiv; pypi; ci)
-[![Docs](https://img.shields.io/badge/docs-live-brightgreen)](https://ibm.github.io/steerability/)
+[![Docs](https://img.shields.io/badge/docs-live-brightgreen)](https://generative-computing.github.io/steerability/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 ![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue)
-[![GitHub License](https://img.shields.io/github/license/IBM/steerability)](https://github.com/IBM/steerability/blob/main/LICENSE)
+[![GitHub License](https://img.shields.io/github/license/generative-computing/steerability)](https://github.com/generative-computing/steerability/blob/main/LICENSE)
 
 ---
 
@@ -14,7 +14,7 @@ The Steerability toolkit is an open source Python package for steering large lan
 
 The toolkit enables the development and evaluation of a wide range of steering methods via reusable components across four model control surfaces (input, structure, state, and output). Features include modular abstractions for the construction of steering methods, functionality for composition of steering methods into [steering pipelines](docs/concepts/steering_pipelines.md), and evaluation of steering pipelines on [Inspect](https://inspect.aisi.org.uk) tasks (including measurement of steering side effects).
 
-To get started, please see the documentation at <https://ibm.github.io/steerability/> and the [example notebooks](examples/index.md).
+To get started, please see the documentation at <https://generative-computing.github.io/steerability/> and the [example notebooks](examples/index.md).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,4 +54,4 @@ addressing the current fragmentation in the field where steering algorithms are 
 within isolated, task-specific environments.[@liang2024controllable]
 
 We encourage the community to use Steerability in their steering workflows. We will continue to develop in the open, and
-encourage users to suggest any additional features or report any issues on our [GitHub page](https://github.com/IBM/steerability).
+encourage users to suggest any additional features or report any issues on our [GitHub page](https://github.com/generative-computing/steerability).

--- a/examples/notebooks/algorithms/act_add.ipynb
+++ b/examples/notebooks/algorithms/act_add.ipynb
@@ -107,8 +107,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/angular_steering.ipynb
+++ b/examples/notebooks/algorithms/angular_steering.ipynb
@@ -101,8 +101,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/best_of_n.ipynb
+++ b/examples/notebooks/algorithms/best_of_n.ipynb
@@ -88,8 +88,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {
@@ -1149,7 +1149,7 @@
     "\n",
     "Best-of-N is a reasonable first method to try when a scoring function is available, since it requires no training, composes with other controls, and costs `n` full decodes per output. The choice of scorer determines the method, as this notebook shows twice with the same driver (keyword reranking, then self-consistency via `MajorityVoteScorer`). The shipped scorers live in `steerability.algorithms.output_control.common.scorers`.\n",
     "\n",
-    "Because every candidate is a full rollout through the composed stacks, a step-level control steers all `n` samples. For example, running RAD under `BestOfN` reranks already-detoxified candidates ([rad.ipynb](rad.ipynb)). For iterative segment-level search with the same scorer contract, see DeAL ([deal.ipynb](deal.ipynb)). See the [output control](https://ibm.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
+    "Because every candidate is a full rollout through the composed stacks, a step-level control steers all `n` samples. For example, running RAD under `BestOfN` reranks already-detoxified candidates ([rad.ipynb](rad.ipynb)). For iterative segment-level search with the same scorer contract, see DeAL ([deal.ipynb](deal.ipynb)). See the [output control](https://generative-computing.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
    ]
   }
  ],

--- a/examples/notebooks/algorithms/budget_forcing.ipynb
+++ b/examples/notebooks/algorithms/budget_forcing.ipynb
@@ -92,8 +92,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {
@@ -861,7 +861,7 @@
     "\n",
     "Budget forcing turns thinking length into an inference-time parameter, i.e., one integer trades answer quality against decode compute, and the \"Wait\" extension adds reasoning on demand without touching weights or prompts. Note that the method only applies to models that externalize their reasoning between think tags.\n",
     "\n",
-    "[phased_decoding.ipynb](generics/phased_decoding.ipynb) demonstrates the generic this preset is built on, including a thinking-intervention plan that splices steering text into the reasoning stream rather than bounding its length. See the [output control](https://ibm.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
+    "[phased_decoding.ipynb](generics/phased_decoding.ipynb) demonstrates the generic this preset is built on, including a thinking-intervention plan that splices steering text into the reasoning stream rather than bounding its length. See the [output control](https://generative-computing.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
    ]
   }
  ],

--- a/examples/notebooks/algorithms/caa.ipynb
+++ b/examples/notebooks/algorithms/caa.ipynb
@@ -96,8 +96,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/cast.ipynb
+++ b/examples/notebooks/algorithms/cast.ipynb
@@ -109,8 +109,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/contrastive_decoding.ipynb
+++ b/examples/notebooks/algorithms/contrastive_decoding.ipynb
@@ -93,8 +93,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {
@@ -811,7 +811,7 @@
     "\n",
     "Contrastive decoding turns a small amateur model into a repetition filter for deterministic decoding, at the cost of one amateur forward pass per generated token; there is no training, and nothing to tune beyond `alpha` and the two weights. Reach for it when you want greedy or low-temperature decoding on open-ended text without the degeneration that plain likelihood maximization produces.\n",
     "\n",
-    "As a step-level control it composes with sampling and with any decoding driver in the toolkit. [dexperts.ipynb](dexperts.ipynb) uses the same contrastive-mixture processor with a different sign structure (an expert and anti-expert contrasted around a separate base model). See the [output control](https://ibm.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
+    "As a step-level control it composes with sampling and with any decoding driver in the toolkit. [dexperts.ipynb](dexperts.ipynb) uses the same contrastive-mixture processor with a different sign structure (an expert and anti-expert contrasted around a separate base model). See the [output control](https://generative-computing.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
    ]
   }
  ],

--- a/examples/notebooks/algorithms/cpo.ipynb
+++ b/examples/notebooks/algorithms/cpo.ipynb
@@ -119,8 +119,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e \".[cpo,inspect]\""
    ]
   },

--- a/examples/notebooks/algorithms/deal.ipynb
+++ b/examples/notebooks/algorithms/deal.ipynb
@@ -107,8 +107,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/dexperts.ipynb
+++ b/examples/notebooks/algorithms/dexperts.ipynb
@@ -92,8 +92,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {
@@ -1171,7 +1171,7 @@
     "\n",
     "DExperts buys attribute steering at decode time for the price of two small-model forwards per generated token, and proxy-tuning shows the recipe needs no attribute-specific training when a tuned/untuned pair already exists. Reach for it when the behavior you want can be named as a difference between two small models you already have.\n",
     "\n",
-    "The control shares its contrastive-mixture processor with [contrastive_decoding.ipynb](contrastive_decoding.ipynb), where a single weaker amateur is contrasted against the base itself. Auxiliary load options (dtype, device) pass through `hf_model_kwargs`. See the [output control](https://ibm.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
+    "The control shares its contrastive-mixture processor with [contrastive_decoding.ipynb](contrastive_decoding.ipynb), where a single weaker amateur is contrasted against the base itself. Auxiliary load options (dtype, device) pass through `hf_model_kwargs`. See the [output control](https://generative-computing.github.io/steerability/concepts/controls/#output-control) section of the docs for the full family."
    ]
   }
  ],

--- a/examples/notebooks/algorithms/directional_ablation.ipynb
+++ b/examples/notebooks/algorithms/directional_ablation.ipynb
@@ -98,8 +98,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/few_shot.ipynb
+++ b/examples/notebooks/algorithms/few_shot.ipynb
@@ -112,8 +112,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/generics/activation_adapter.ipynb
+++ b/examples/notebooks/algorithms/generics/activation_adapter.ipynb
@@ -92,8 +92,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/generics/contrastive_guidance.ipynb
+++ b/examples/notebooks/algorithms/generics/contrastive_guidance.ipynb
@@ -87,8 +87,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/generics/phased_decoding.ipynb
+++ b/examples/notebooks/algorithms/generics/phased_decoding.ipynb
@@ -110,8 +110,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/generics/search_decoding.ipynb
+++ b/examples/notebooks/algorithms/generics/search_decoding.ipynb
@@ -90,8 +90,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/generics/stopping_rules.ipynb
+++ b/examples/notebooks/algorithms/generics/stopping_rules.ipynb
@@ -89,8 +89,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/generics/value_guidance.ipynb
+++ b/examples/notebooks/algorithms/generics/value_guidance.ipynb
@@ -94,8 +94,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/gepa.ipynb
+++ b/examples/notebooks/algorithms/gepa.ipynb
@@ -79,8 +79,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/algorithms/iti.ipynb
+++ b/examples/notebooks/algorithms/iti.ipynb
@@ -112,8 +112,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/pasta.ipynb
+++ b/examples/notebooks/algorithms/pasta.ipynb
@@ -109,8 +109,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/prewrite.ipynb
+++ b/examples/notebooks/algorithms/prewrite.ipynb
@@ -119,8 +119,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e \".[eval]\""
    ]
   },

--- a/examples/notebooks/algorithms/rad.ipynb
+++ b/examples/notebooks/algorithms/rad.ipynb
@@ -113,7 +113,7 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
     "# %cd steerability"
    ]
   },

--- a/examples/notebooks/algorithms/sasa.ipynb
+++ b/examples/notebooks/algorithms/sasa.ipynb
@@ -112,7 +112,7 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
     "# %cd steerability"
    ]
   },

--- a/examples/notebooks/algorithms/system_prompt.ipynb
+++ b/examples/notebooks/algorithms/system_prompt.ipynb
@@ -79,8 +79,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/wrappers/mergekit.ipynb
+++ b/examples/notebooks/algorithms/wrappers/mergekit.ipynb
@@ -75,8 +75,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/algorithms/wrappers/trl.ipynb
+++ b/examples/notebooks/algorithms/wrappers/trl.ipynb
@@ -90,8 +90,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability"
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability"
    ]
   },
   {

--- a/examples/notebooks/recipes/honest_persona_prompting.ipynb
+++ b/examples/notebooks/recipes/honest_persona_prompting.ipynb
@@ -88,8 +88,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/recipes/routed_decoding/routed_decoding.ipynb
+++ b/examples/notebooks/recipes/routed_decoding/routed_decoding.ipynb
@@ -99,8 +99,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/recipes/vllm_serve.ipynb
+++ b/examples/notebooks/recipes/vllm_serve.ipynb
@@ -62,8 +62,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/recipes/working_with_spipes.ipynb
+++ b/examples/notebooks/recipes/working_with_spipes.ipynb
@@ -62,8 +62,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/examples/notebooks/studies/routing_vs_prompting.ipynb
+++ b/examples/notebooks/studies/routing_vs_prompting.ipynb
@@ -62,8 +62,8 @@
    },
    "outputs": [],
    "source": [
-    "# !git clone https://github.com/IBM/steerability.git\n",
-    "# %cd Steerability\n",
+    "# !git clone https://github.com/generative-computing/steerability.git\n",
+    "# %cd steerability\n",
     "# !pip install -q -e ."
    ]
   },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Steerability
-site_url: https://ibm.github.io/steerability/
-repo_name: IBM/steerability
-repo_url: https://github.com/IBM/steerability
+site_url: https://generative-computing.github.io/steerability/
+repo_name: generative-computing/steerability
+repo_url: https://github.com/generative-computing/steerability
 
 theme:
   name: material


### PR DESCRIPTION
Updates stale URLs left over from the org and package rename, replacing the repo path `IBM/steerability` with `generative-computing/steerability` and the docs host `ibm.github.io` with `generative-computing.github.io`. Both old targets currently 404.

Covers the README logos, license badge and docs links, the `mkdocs.yml` repo and site URLs, the `CONTRIBUTING.md` fork and compare links, the `docs/index.md` GitHub link, the `AGENTS.md` docs link, and the clone URL in 32 notebook setup cells. The setup cells also had `%cd Steerability` with a capital `S`, which fails after cloning since the clone creates a lowercase directory.

`IBM/vLLM-Hook` is unchanged since it points at a separate repo, as is the attribution prose that is not a URL.